### PR TITLE
Small typo fixed: Missing ">"

### DIFF
--- a/lulip.lua
+++ b/lulip.lua
@@ -185,6 +185,6 @@ function dump(self, file)
 <td class="code"><code class="prettyprint">%s</code></td></tr>]],
 l, d[1], d[2]/1000, files[d[3]][ln]))
    end
-   f:write('</tbody></table></body></html')
+   f:write('</tbody></table></body></html>')
    f:close()
 end


### PR DESCRIPTION
Hi there, thanks for the veeeeeeery helpful lulip! Found a small typo you might want to fix. Since I use "links" in a terminal to view the profiling report, that was an easy find - it puts the closing tag into the document view :-)
